### PR TITLE
support for reading and writing neqsim objects to xml

### DIFF
--- a/neqsim/__init__.py
+++ b/neqsim/__init__.py
@@ -26,3 +26,19 @@ def setDatabase(connectionString):
     from neqsim.neqsimpython import jNeqSim
     jNeqSim.util.database.NeqSimDataBase.setConnectionString(connectionString)
     jNeqSim.util.database.NeqSimDataBase.setCreateTemporaryTables(True)
+
+def save_xml(javaobject, filename):
+    xstream = jpype.JPackage('com.thoughtworks.xstream')
+    streamer = xstream.XStream()
+    xml = streamer.toXML(javaobject)
+    print(xml,  file=open(filename, 'w'))
+    return xml
+
+def open_xml(filename):
+    xstream = jpype.JPackage('com.thoughtworks.xstream')
+    security = jpype.JPackage('com.thoughtworks.xstream.security')
+    streamer = xstream.XStream()
+    streamer.addPermission(security.AnyTypePermission.ANY)
+    str = open(filename, 'r').read()
+    neqsimobj = streamer.fromXML(str)
+    return neqsimobj

--- a/neqsim/__init__.py
+++ b/neqsim/__init__.py
@@ -4,7 +4,7 @@ This module is a Python interface to the NeqSim Java library.
 It uses the Jpype module for bridging python and Java.
 """
 
-from .neqsimpython import *
+from neqsim.neqsimpython import jNeqSim, jpype
 
 def methods(checkClass):
     methods = checkClass.getClass().getMethods()
@@ -23,7 +23,6 @@ def has_tabulate():
 
 
 def setDatabase(connectionString):
-    from neqsim.neqsimpython import jNeqSim
     jNeqSim.util.database.NeqSimDataBase.setConnectionString(connectionString)
     jNeqSim.util.database.NeqSimDataBase.setCreateTemporaryTables(True)
 
@@ -31,14 +30,13 @@ def save_xml(javaobject, filename):
     xstream = jpype.JPackage('com.thoughtworks.xstream')
     streamer = xstream.XStream()
     xml = streamer.toXML(javaobject)
-    print(xml,  file=open(filename, 'w'))
+    print(xml, file=open(filename, 'w'))
     return xml
 
 def open_xml(filename):
     xstream = jpype.JPackage('com.thoughtworks.xstream')
-    security = jpype.JPackage('com.thoughtworks.xstream.security')
     streamer = xstream.XStream()
-    streamer.addPermission(security.AnyTypePermission.ANY)
+    streamer.addPermission(xstream.security.AnyTypePermission.ANY)
     str = open(filename, 'r').read()
     neqsimobj = streamer.fromXML(str)
     return neqsimobj

--- a/tests/test_NeqSim.py
+++ b/tests/test_NeqSim.py
@@ -4,6 +4,7 @@ Created on Thu Jan  3 22:24:08 2019
 
 @author: ESOL
 """
+import os
 from neqsim.neqsimpython import jNeqSim
 
 
@@ -232,10 +233,17 @@ def test_fullOffshoreProcess():
     exportGas = stream(exportCompressor.getOutStream())
     runProcess()
 
-def testwriteandopen():
+def testwriteandopen(tmp_path):
     import neqsim
     from neqsim.thermo import createfluid
+
+    temp_dir = tmp_path / "test"
+    os.mkdir(temp_dir)
+
+    temp_file =  temp_dir / "name.xml"  
+
     fluid1 = createfluid('dry gas')
-    neqsim.save_xml(fluid1, 'name.xml')
-    fluid2 = neqsim.open_xml('name.xml')
+    neqsim.save_xml(fluid1, temp_file)
+    fluid2 = neqsim.open_xml(temp_file)
+    
     assert fluid1.getTemperature() == fluid2.getTemperature()

--- a/tests/test_NeqSim.py
+++ b/tests/test_NeqSim.py
@@ -231,3 +231,11 @@ def test_fullOffshoreProcess():
     exportCompressor.setOutletPressure(200.0, 'bara')
     exportGas = stream(exportCompressor.getOutStream())
     runProcess()
+
+def testwriteandopen():
+    import neqsim
+    from neqsim.thermo import createfluid
+    fluid1 = createfluid('dry gas')
+    neqsim.save_xml(fluid1, 'name.xml')
+    fluid2 = neqsim.open_xml('name.xml')
+    assert fluid1.getTemperature() == fluid2.getTemperature()


### PR DESCRIPTION
add support for write and open java neqsim objects.

Implement following functionality:

```
    fluid1 = createfluid('dry gas')
    neqsim.save_xml(fluid1, 'name.xml')
    fluid2 = neqsim.open_xml('name.xml')
```